### PR TITLE
Fix data exposure in logs: strip record content from exception log calls

### DIFF
--- a/src/main/java/com/couchbase/connect/kafka/SourceDocumentLifecycle.java
+++ b/src/main/java/com/couchbase/connect/kafka/SourceDocumentLifecycle.java
@@ -104,7 +104,6 @@ public class SourceDocumentLifecycle {
     if (enabled()) {
       LinkedHashMap<String, Object> details = new LinkedHashMap<>();
       details.put("topic", record.topic());
-      details.put("key", record.key());
       details.put("kafkaPartition", record.kafkaPartition());
       details.put("sourcePartition", record.sourcePartition());
       details.put("sourceOffset", record.sourceOffset());
@@ -146,7 +145,6 @@ public class SourceDocumentLifecycle {
       // In case the user customized their logging config to exclude MDC
       getConnectorContextFromLoggingContext().ifPresent(it -> message.put("context", it));
 
-      message.put("documentId", sourceRecord.getCouchbaseDocumentId());
       message.putAll(milestoneDetails);
       message.put("taskUuid", taskUuid);
       doLog(message);
@@ -162,7 +160,6 @@ public class SourceDocumentLifecycle {
       // In case the user customized their logging config to exclude MDC
       getConnectorContextFromLoggingContext().ifPresent(it -> message.put("context", it));
 
-      message.put("documentId", event.getQualifiedKey());
       message.putAll(milestoneDetails);
       message.put("taskUuid", taskUuid);
       doLog(message);

--- a/src/main/java/com/couchbase/connect/kafka/handler/sink/AnalyticsSinkHandler.java
+++ b/src/main/java/com/couchbase/connect/kafka/handler/sink/AnalyticsSinkHandler.java
@@ -178,7 +178,7 @@ public class AnalyticsSinkHandler implements SinkHandler {
         try {
           node = JsonObject.fromJson(doc.content());
         } catch (Exception e) {
-          log.warn("could not generate analytics statement from node (not json): {}", e.getClass().getName());
+          log.warn("could not generate n1ql statement from node (not json): {}", e.getClass().getName());
           continue;
         }
 

--- a/src/main/java/com/couchbase/connect/kafka/handler/sink/AnalyticsSinkHandler.java
+++ b/src/main/java/com/couchbase/connect/kafka/handler/sink/AnalyticsSinkHandler.java
@@ -178,7 +178,7 @@ public class AnalyticsSinkHandler implements SinkHandler {
         try {
           node = JsonObject.fromJson(doc.content());
         } catch (Exception e) {
-          log.warn("could not generate n1ql statement from node (not json): {}", e.getClass().getName());
+          log.warn("could not generate analytics statement from node (not json): {}", e.getClass().getName());
           continue;
         }
 

--- a/src/main/java/com/couchbase/connect/kafka/handler/sink/AnalyticsSinkHandler.java
+++ b/src/main/java/com/couchbase/connect/kafka/handler/sink/AnalyticsSinkHandler.java
@@ -75,7 +75,7 @@ public class AnalyticsSinkHandler implements SinkHandler {
     try {
       node = JsonObject.fromJson(object);
     } catch (Exception e) {
-      log.warn("could not generate analytics statement from node (not json)", e);
+      log.warn("could not generate analytics statement from node (not json): {}", e.getClass().getName());
     }
 
     if (node != null && node.isEmpty()) {
@@ -178,7 +178,7 @@ public class AnalyticsSinkHandler implements SinkHandler {
         try {
           node = JsonObject.fromJson(doc.content());
         } catch (Exception e) {
-          log.warn("could not generate n1ql statement from node (not json)", e);
+          log.warn("could not generate n1ql statement from node (not json): {}", e.getClass().getName());
           continue;
         }
 

--- a/src/main/java/com/couchbase/connect/kafka/handler/sink/N1qlSinkHandler.java
+++ b/src/main/java/com/couchbase/connect/kafka/handler/sink/N1qlSinkHandler.java
@@ -97,7 +97,7 @@ public class N1qlSinkHandler implements SinkHandler {
     try {
       node = JsonObject.fromJson(doc.content());
     } catch (Exception e) {
-      log.warn("could not generate n1ql statement from node (not json)", e);
+      log.warn("could not generate n1ql statement from node (not json): {}", e.getClass().getName());
       return SinkAction.ignore();
     }
 

--- a/src/main/java/com/couchbase/connect/kafka/handler/sink/SubDocumentSinkHandler.java
+++ b/src/main/java/com/couchbase/connect/kafka/handler/sink/SubDocumentSinkHandler.java
@@ -112,9 +112,6 @@ public class SubDocumentSinkHandler implements SinkHandler {
     }
 
     SubdocOperation operation = getOperation(documentId, doc);
-    if (operation == null) {
-      return SinkAction.ignore();
-    }
 
     MutateInSpec mutation;
 
@@ -167,7 +164,7 @@ public class SubDocumentSinkHandler implements SinkHandler {
 
     } catch (IOException | DocumentPathExtractor.DocumentPathNotFoundException e) {
       log.error("Failed to extract subdocument path: {}", e.getClass().getName());
-      return null;
+      return new SubdocOperation(documentId, null, null);
     }
   }
 

--- a/src/main/java/com/couchbase/connect/kafka/handler/sink/SubDocumentSinkHandler.java
+++ b/src/main/java/com/couchbase/connect/kafka/handler/sink/SubDocumentSinkHandler.java
@@ -112,6 +112,9 @@ public class SubDocumentSinkHandler implements SinkHandler {
     }
 
     SubdocOperation operation = getOperation(documentId, doc);
+    if (operation == null) {
+      return SinkAction.ignore();
+    }
 
     MutateInSpec mutation;
 
@@ -164,7 +167,7 @@ public class SubDocumentSinkHandler implements SinkHandler {
 
     } catch (IOException | DocumentPathExtractor.DocumentPathNotFoundException e) {
       log.error("Failed to extract subdocument path: {}", e.getClass().getName());
-      return new SubdocOperation(documentId, null, null);
+      return null;
     }
   }
 

--- a/src/main/java/com/couchbase/connect/kafka/handler/sink/SubDocumentSinkHandler.java
+++ b/src/main/java/com/couchbase/connect/kafka/handler/sink/SubDocumentSinkHandler.java
@@ -163,7 +163,7 @@ public class SubDocumentSinkHandler implements SinkHandler {
       return new SubdocOperation(documentId, extraction.getPathValue(), extraction.getData());
 
     } catch (IOException | DocumentPathExtractor.DocumentPathNotFoundException e) {
-      log.error(e.getMessage(), e);
+      log.error("Failed to extract subdocument path: {}", e.getClass().getName());
       return new SubdocOperation(documentId, null, null);
     }
   }

--- a/src/main/java/com/couchbase/connect/kafka/handler/source/RawJsonSourceHandler.java
+++ b/src/main/java/com/couchbase/connect/kafka/handler/source/RawJsonSourceHandler.java
@@ -143,7 +143,7 @@ public class RawJsonSourceHandler implements SourceHandler {
 
         final byte[] document = docEvent.content();
         if (!isValidJson(document)) {
-          LOGGER.warn("Skipping non-JSON document: bucket={} key={}", docEvent.bucket(), docEvent.qualifiedKey());
+          LOGGER.warn("Skipping non-JSON document: bucket={}", docEvent.bucket());
           return false;
         }
 

--- a/src/main/java/com/couchbase/connect/kafka/util/KafkaRetryHelper.java
+++ b/src/main/java/com/couchbase/connect/kafka/util/KafkaRetryHelper.java
@@ -117,8 +117,8 @@ public class KafkaRetryHelper implements Closeable {
         String retryTimeoutName = ConfigHelper.keyName(CouchbaseSinkConfig.class, CouchbaseSinkConfig::retryTimeout);
 
         log.error("Initial attempt for {} failed. Retry is disabled. Connector will terminate. " +
-                "To mitigate this kind of failure, enable retry by setting the '{}' connector config property.",
-            actionDescription, retryTimeoutName, e);
+                "To mitigate this kind of failure, enable retry by setting the '{}' connector config property. Exception: {}",
+            actionDescription, retryTimeoutName, e.getClass().getName());
         throw e;
       }
 
@@ -131,8 +131,8 @@ public class KafkaRetryHelper implements Closeable {
         throw new RetriableException("Retry for " + actionDescription + " failed. Will try again later.", e);
       }
 
-      log.error("Retry for {} failed. Retry timeout ({}) expired. Connector will terminate.",
-          actionDescription, retryTimeout, e);
+      log.error("Retry for {} failed. Retry timeout ({}) expired. Connector will terminate. Exception: {}",
+          actionDescription, retryTimeout, e.getClass().getName());
       throw e;
     }
   }


### PR DESCRIPTION
## Summary

Fixes CC-42201, CC-42202, CC-42203, CC-42204, CC-42205, CC-42207 — all data exposure vulnerabilities where customer record content, document IDs, or Kafka record keys were leaking into connector logs.

### Changes

| File | Issue | Fix |
|---|---|---|
| `KafkaRetryHelper.java` | `log.error(..., e)` on sink put failure echoes record content via exception chain | Log only `e.getClass().getName()` instead of full exception |
| `SubDocumentSinkHandler.java` | `log.error(e.getMessage(), e)` on subdoc path extraction failure | Replace with static message + exception class name |
| `AnalyticsSinkHandler.java` | `log.warn(..., e)` in `getJsonObject` and `handleBatch` echoes document body | Log only exception class name |
| `N1qlSinkHandler.java` | `log.warn(..., e)` on `JsonObject.fromJson` failure echoes record content | Log only exception class name |
| `RawJsonSourceHandler.java` | `LOGGER.warn(... key={}, docEvent.qualifiedKey())` logs document ID (record key) for non-JSON documents | Removed `key=` from the log message |
| `SourceDocumentLifecycle.java` | Logs Kafka record key (`record.key()`) and Couchbase document ID at INFO when lifecycle flag enabled | Removed `key` from `logConvertedToKafkaRecord` details; removed `documentId` from both `logMilestone` overloads |

## Test plan

- [ ] Build passes: `mvn clean install -DskipTests`
- [ ] Unit tests pass: `mvn test`
- [ ] No record content, document IDs, or Kafka record keys appear in ERROR/WARN/INFO logs on sink write failure or non-JSON document skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)